### PR TITLE
fix: prepare gh pages deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-      - run: npm ci
+      - run: npm install
       - run: npm run build
       - name: Assert dist exists
         run: test -d dist || (echo "::error::dist/ missing (build failed)"; exit 1)

--- a/404.html
+++ b/404.html
@@ -2,13 +2,22 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <title>404</title>
     <script>
-      var base='/mancalagame/';
-      if(location.pathname !== base){
-        var path = location.pathname.replace(base,'');
-        var dest = base + (path ? '#' + path : '');
-        location.replace(dest);
-      }
+      (function () {
+        // SPA fallback for GitHub Pages under /mancalagame/
+        var base = '/mancalagame/';
+        if (!location.pathname.startsWith(base)) {
+          location.replace(base);
+          return;
+        }
+        if (location.pathname !== base) {
+          var extra = location.pathname.slice(base.length);
+          var q = location.search || '';
+          var h = location.hash || '';
+          location.replace(base + '#' + extra + q + h);
+        }
+      })();
     </script>
   </head>
   <body></body>

--- a/src/styles.css
+++ b/src/styles.css
@@ -24,6 +24,7 @@ body {
   align-items: center;
   justify-content: center;
   font-weight: bold;
+  position: relative; /* ensure .count centers within the store */
 }
 .store.north {
   grid-column: 1;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "lib": ["DOM", "DOM.Iterable", "WebWorker", "ESNext"],
     "allowJs": false,
     "skipLibCheck": true,
     "esModuleInterop": false,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,16 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   base: '/mancalagame/',
-  plugins: [react()]
+  plugins: [
+    react(),
+    {
+      name: 'html-base-path',
+      enforce: 'pre',
+      transform(code, id) {
+        if (id.endsWith('index.html')) {
+          return code.replace(/\$\{import.meta.env.BASE_URL\}/g, '');
+        }
+      }
+    }
+  ]
 });


### PR DESCRIPTION
## Summary
- overhaul Pages workflow to install, build, and deploy artifact
- ensure WebWorker typings and tighten CSS for store centering
- add SPA fallback and base-path handling for /mancalagame/

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ca225143c832a9efca0e10c3fc489