### PR TITLE
Fix Vite base path and index asset paths for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="${import.meta.env.BASE_URL}src/main.tsx"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,16 +3,5 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   base: '/mancalagame/',
-  plugins: [
-    react(),
-    {
-      name: 'html-base-path',
-      enforce: 'pre',
-      transform(code, id) {
-        if (id.endsWith('index.html')) {
-          return code.replace(/\$\{import.meta.env.BASE_URL\}/g, '');
-        }
-      }
-    }
-  ]
+  plugins: [react()],
 });


### PR DESCRIPTION
## Summary
- remove custom HTML base plugin and configure Vite with `base: '/mancalagame/'`
- adjust index.html asset paths for GitHub Pages

## Testing
- `npm run build`
- ⚠️ `npx serve gh-test -l 4173` *(package installation blocked, could not run serve)*
- ⚠️ `npm install playwright` *(package installation blocked, could not run Playwright)*

------
https://chatgpt.com/codex/tasks/task_e_689cbcbee280832a8fb50d33b0210160